### PR TITLE
autogen.sh: Don't break with github release tarballs.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -36,9 +36,10 @@ gnulib-tool \
 	unistd \
 	vfprintf-posix \
 	vsnprintf-posix
-rm gnulib/*/.gitignore
-git checkout HEAD^ gnulib/.gitignore
-git add gnulib
+
+rm -f gnulib/*/.gitignore
+git checkout HEAD^ gnulib/.gitignore || true
+git add gnulib || true
 
 autoreconf -i -f
 


### PR DESCRIPTION
Github release tarballs do not contain any `.git` directories or files and `autogen.sh` will fail if these are missing because of `set -e`.

This commit will add the minimum requirements needed for `autogen.sh` to not break in these cases and still allow building metalog. Unfortunately because of the `gnulib` requirement just using `autoreconf -fi` is not enough.