### PR TITLE
Add support for %[nnn]N nanoseconds in stamp_fmt

### DIFF
--- a/man/metalog.conf.5.in
+++ b/man/metalog.conf.5.in
@@ -132,7 +132,9 @@ The program is passed the date, the matching program name, and the log message.
 .TP
 \fBstamp_fmt\fR = \fI"%b %e %T"\fR
 Format of the human readable timestamp prepended to all log messages.
-This format string is passed literally to the
+The format string supports all conversion specifications from strftime plus %[nnn]N for nanoseconds
+(default: nine numbers long, can be shortened with nnn < 9).
+The format string with %[nnn]N replaced is then passed to the
 .BR strftime (3)
 function.
 An empty string is used to disable timestamps (for cases where the log messages


### PR DESCRIPTION
Hi!
During usage of metalog I've had the wish to have a more precise timestamps than seconds.
By looking over the busybox code (coreutils/date.c) I've found an example how nanoseconds can be implemented.

Therefore I adopted the busybox snippet a little and tested this snippet positively (in a seperate test binary I'v also tested with valgrind: No leaks are possible...).

With this pull request it's possible to use %[nnn]N as conversion specification where nnn is optional.   By default all 9 numbers are printed. By using nnn < 9 one can shorten it to e.g. milliseconds by using %3N.

Would be nice to have it merged here :-)

Cheers
Roman