### PR TITLE
Add examples for time format and remote logging to config file

### DIFF
--- a/metalog.conf
+++ b/metalog.conf
@@ -4,6 +4,16 @@ maxsize  = 1048576  # size in bytes (1048576 = 1 megabyte)
 maxtime  = 86400    # time in seconds (86400 = 1 day)
 maxfiles = 5        # num files per directory
 
+# Format of the timestamp: YYYY-MM-DD HH:MM:SS.NNN
+#stamp_fmt = "%F %T.%3N"
+
+# Configures a remote log server
+#remote_host = 192.168.1.2
+#remote_port = 514
+
+# Send all logs via UDP to a remote log server
+#remote_log = 1
+
 # This will capture all of the internal log messages that metalog itself
 # generates.  If you use any "command" options below, you will want this
 # as metalog generates a lot of status messages whenever it executes a
@@ -52,6 +62,8 @@ Kernel messages :
     facility = "kern"
     logdir   = "/var/log/kernel"
     break    = 1
+# Additionally send this log entries via UDP to a remote log server
+#    remote_log = 1
 
 Crond :
 

--- a/src/metalog.c
+++ b/src/metalog.c
@@ -1287,6 +1287,9 @@ static int log_udp(char *buf, int bsize)
     buf[bsize] = '\0';
     if (write(1, buf, strlen(buf)) != (ssize_t) strlen(buf))
         return -1;
+    if (write(1, "\n", 1) != 1)
+        return -1;
+
     return log_line(LOGLINETYPE_SYSLOG, buf);
 }
 


### PR DESCRIPTION
The recently added features show up in the example config file. They are commented, so the default config file behaves like it did before.