### PR TITLE
Add setting log permissions to configuration

### DIFF
--- a/README
+++ b/README
@@ -361,6 +361,9 @@ Linux. Valid values are from 0 to 7. The default is 7.
 - '-C <configuration file>' or '--configfile=<configuration file>' : use an
 alternative configuration file.
 
+- '-g <group>' or '--group=<group>' : change the GID of the metalog process.
+Created files will be owned by this group.
+
 - '-h' or '--help' : show help and version number.
 
 - '-p <filename>' or '--pidfile=<filename>' : set the name of the file

--- a/README
+++ b/README
@@ -225,6 +225,13 @@ Defaults to 0 (i.e. repeated messages will be summarized)
 directory doesn't exist, it will be automatically created when the first
 matching message will be logged (the parent directory has to exist, though) .
 
+* perms = <mode> : permissions for the log directory. Defaults to 0700
+
+Example : Let those in the group with the GID of the process read the log.
+Don't forget to run metalog as the group.
+
+  perms    = 0770
+
 * command = <path/to/command> : run a program or a shell-script when all
 conditions are met. This directive is not incompatible with logdir : a
 message can be both logged and passed to an external command. When the

--- a/man/metalog.8.in
+++ b/man/metalog.8.in
@@ -32,6 +32,10 @@ Set the console log level (Linux only).
 .BR \-C ", " \-\-configfile = \fR\fIfile\fR
 Use an alternate configuration file.
 .TP
+.BR \-g ", " \-\-group = \fR\fIgroup\fR
+Change the GID of the metalog process.
+Created files will be owned by this group.
+.TP
 .BR \-h ", " \-\-help
 Output help information and exit.
 .TP

--- a/man/metalog.conf.5.in
+++ b/man/metalog.conf.5.in
@@ -91,6 +91,9 @@ By default, \fBmaximum\fR is the largest possible level.
 Files will be written under the specified directory. The special value \fI"NONE"\fR will
 skip the log message.
 .TP
+\fBperms\fR = \fI<mode>\fR
+Permissions for the log directory. Defaults to \fI0700\fR
+.TP
 \fBprogram\fR = \fI"name"\fR
 Can be used to do filtering instead of \fBfacility\fR.
 Remember to use the executable name.

--- a/metalog.conf
+++ b/metalog.conf
@@ -4,6 +4,9 @@ maxsize  = 1048576  # size in bytes (1048576 = 1 megabyte)
 maxtime  = 86400    # time in seconds (86400 = 1 day)
 maxfiles = 5        # num files per directory
 
+# Permissions for log directories. 0750 allows group to read logs. 0700 is default.
+#perms    = 0750
+
 # Format of the timestamp: YYYY-MM-DD HH:MM:SS.NNN
 #stamp_fmt = "%F %T.%3N"
 
@@ -56,6 +59,10 @@ Password failures :
     regex    = "ILLEGAL ROOT LOGIN"
     logdir   = "/var/log/pwdfail"
 #    command  = "/usr/local/sbin/mail_pwd_failures.sh"
+
+# If you changed default permissions it may be a good idea to set more
+# restrictive permissions on sensitive logs.
+#    perms    = 0700
 
 Kernel messages :
 

--- a/src/metalog.c
+++ b/src/metalog.c
@@ -220,7 +220,7 @@ static int parseLine(char * const line, ConfigBlock **cur_block,
             else
                 free(logdir);
             new_output->fp = NULL;
-	    new_output->perms = (*cur_block)->perms;
+            new_output->perms = (*cur_block)->perms;
             new_output->size = (off_t) 0;
             new_output->maxsize = (*cur_block)->maxsize;
             new_output->maxfiles = (*cur_block)->maxfiles;
@@ -359,7 +359,7 @@ static int configParser(const char * const file)
             (off_t) DEFAULT_MAXSIZE,   /* maxsize */
             DEFAULT_MAXFILES,          /* maxfiles */
             (time_t) DEFAULT_MAXTIME,  /* maxtime */
-	    (mode_t) DEFAULT_PERMS,    /* perms */
+            (mode_t) DEFAULT_PERMS,    /* perms */
             NULL,                      /* output */
             NULL,                      /* command */
             NULL,                      /* program */
@@ -1647,17 +1647,17 @@ static void dodaemonize(void)
 
 static void setgroup(void)
 {
-	if (group_name == NULL) return;
-	struct group *g;
-	errno = 0;
-	if ((g = getgrnam(group_name)) == NULL) {
-	    if(errno == 0)
-	        err("Failed to set group: group '%s' not found", group_name);
-	    else
-	        errp("Failed to set group");
-	}
-	if (setgid(g->gr_gid) == -1)
-	    errp("Failed to set group");
+        if (group_name == NULL) return;
+        struct group *g;
+        errno = 0;
+        if ((g = getgrnam(group_name)) == NULL) {
+            if(errno == 0)
+                err("Failed to set group: group '%s' not found", group_name);
+            else
+                errp("Failed to set group");
+        }
+        if (setgid(g->gr_gid) == -1)
+            errp("Failed to set group");
 }
 
 __attribute__ ((noreturn))
@@ -1700,9 +1700,9 @@ static void parseOptions(int argc, char *argv[])
         case 'C' :
             config_file = xstrdup(optarg);
             break;
-	case 'g' :
-	    group_name = xstrdup(optarg);
-	    break;
+        case 'g' :
+            group_name = xstrdup(optarg);
+            break;
         case 'v' :
             ++verbose;
             break;

--- a/src/metalog.c
+++ b/src/metalog.c
@@ -189,6 +189,11 @@ static int parseLine(char * const line, ConfigBlock **cur_block,
             if ((*cur_block)->output != NULL) {
                 (*cur_block)->output->showrepeats = (*cur_block)->showrepeats;
             }
+        } else if (strcasecmp(keyword, "perms") == 0) {
+            (*cur_block)->perms = (mode_t) strtoul(value, NULL, 8);
+            if ((*cur_block)->output != NULL) {
+                (*cur_block)->output->perms = (*cur_block)->perms;
+            }
         } else if (strcasecmp(keyword, "logdir") == 0) {
             char *logdir = NULL;
             Output *outputs_scan = outputs;
@@ -215,6 +220,7 @@ static int parseLine(char * const line, ConfigBlock **cur_block,
             else
                 free(logdir);
             new_output->fp = NULL;
+	    new_output->perms = (*cur_block)->perms;
             new_output->size = (off_t) 0;
             new_output->maxsize = (*cur_block)->maxsize;
             new_output->maxfiles = (*cur_block)->maxfiles;
@@ -353,6 +359,7 @@ static int configParser(const char * const file)
             (off_t) DEFAULT_MAXSIZE,   /* maxsize */
             DEFAULT_MAXFILES,          /* maxfiles */
             (time_t) DEFAULT_MAXTIME,  /* maxtime */
+	    (mode_t) DEFAULT_PERMS,    /* perms */
             NULL,                      /* output */
             NULL,                      /* command */
             NULL,                      /* program */
@@ -849,7 +856,7 @@ static int writeLogLine(Output * const output, const char * const date,
 
         testdir:
         if (stat(output->directory, &st) < 0) {
-            if (mkdir(output->directory, OUTPUT_DIR_PERMS) < 0) {
+            if (mkdir(output->directory, output->perms) < 0) {
                 warnp("Can't create [%s]", output->directory);
                 return -1;
             }

--- a/src/metalog.h
+++ b/src/metalog.h
@@ -37,6 +37,7 @@
 #include <sys/wait.h>
 #include <netinet/in.h>
 #include <netdb.h>
+#include <grp.h>
 
 #ifndef HAVE_SYSLOG_NAMES
 # include "syslognames.h"

--- a/src/metalog.h
+++ b/src/metalog.h
@@ -96,6 +96,7 @@ typedef struct RemoteHost_ {
 
 typedef struct Output_ {
     char *directory;
+    mode_t perms;
     FILE *fp;
     off_t size;
     off_t maxsize;
@@ -130,6 +131,7 @@ typedef struct ConfigBlock_ {
     off_t maxsize;
     int maxfiles;
     time_t maxtime;
+    mode_t perms;
     Output *output;
     const char *command;
     const char *program;
@@ -168,7 +170,7 @@ typedef enum LogLineType_ {
 #define CF_PROGNAME_KERNEL "kernel"
 #define OUTPUT_DIR_TIMESTAMP ".timestamp"
 #define OUTPUT_DIR_CURRENT "current"
-#define OUTPUT_DIR_PERMS 0700
+#define DEFAULT_PERMS 0700
 #define OUTPUT_DIR_LOGFILES_PREFIX "log-"
 #define OUTPUT_DIR_LOGFILES_SUFFIX "%Y-%m-%d-%H:%M:%S"
 #define DEFAULT_CONFIG_FILE CONFDIR "/metalog.conf"

--- a/src/metalog_p.h
+++ b/src/metalog_p.h
@@ -6,7 +6,7 @@
 #else
 # define KLOGCTL_OPTIONS ""
 #endif
-#define GETOPT_OPTIONS KLOGCTL_OPTIONS "aBC:hp:sVvN"
+#define GETOPT_OPTIONS KLOGCTL_OPTIONS "aBC:g:hp:sVvN"
 
 static struct option long_options[] = {
     { "async",        0, NULL, 'a' },
@@ -15,6 +15,7 @@ static struct option long_options[] = {
     { "consolelevel", 1, NULL, 'c' },
 #endif
     { "configfile",   1, NULL, 'C' },
+    { "group",        1, NULL, 'g' },
     { "help",         0, NULL, 'h' },
     { "no-kernel",    0, NULL, 'N' },
     { "pidfile",      1, NULL, 'p' },
@@ -42,5 +43,6 @@ static bool do_kernel_log = true;
 static signed char daemonize;
 static const char *pid_file = DEFAULT_PID_FILE;
 static const char *config_file = DEFAULT_CONFIG_FILE;
+static const char *group_name = NULL;
 
 #endif


### PR DESCRIPTION
I added some functionality to allow management of access to logs. It lets you define permissions in the configuration file. There is also a option to run metalog with a different GID. I have been testing these changes on my system for a few days and encountered no bugs. I'd love to see this merged and hope someone else will find this useful.