### PR TITLE
Fix behavior of (program_)?regex and (program_)?neg_regex conditions.

### DIFF
--- a/man/metalog.conf.5.in
+++ b/man/metalog.conf.5.in
@@ -99,15 +99,22 @@ Can be used to do filtering instead of \fBfacility\fR.
 Remember to use the executable name.
 .TP
 \fBregex\fR = \fI"perl compatible regular expression"\fR
-Can be used when you want to log all messages that match the \fIpattern\fR
+Can be used when you only want to log messages that match the \fIpattern\fR
 (like "invalid", "fail", etc...) to send them to a single directory.
 
-Multiple \fBregex\fR may be defined in a single section.
+Multiple \fBregex\fR may be defined in a single section, only one must match.
 .TP
 \fBneg_regex\fR = \fI"perl compatible regular expression"\fR
-Can be used when you want to log all messages that do not match the \fIpattern\fR.
+Can be used when you only want to log messages that do not match the \fIpattern\fR.
 
-Multiple \fBneg_regex\fR may be defined in a section.
+A \fBneg_regex\fR match will override any \fBregex\fR matches and not log the
+message.
+
+When one or more \fBregex\fR are provided, at least one of them must match to
+log the message. The lack of any \fBregex\fR will result in message being
+logged when no \fBneg_regex\fR match.
+
+Multiple \fBneg_regex\fR may be defined in a section, only one must match.
 .TP
 \fBpostrotate_cmd\fR = \fI"/path/to/a/program"\fR
 Run specified program after a log file has been rotated.
@@ -118,12 +125,19 @@ The program is passed the date, the program name ("metalog"), and the new logfil
 Similar to \fBprogram\fR, this is a regex that matches the program name to send
 all messages from related programs to the same log file.
 
-Multiple \fBprogram_regex\fR may be defined in a section.
+Multiple \fBprogram_regex\fR may be defined in a section, only one must match.
 .TP
 \fBprogram_neg_regex\fR = \fI"perl compatible regular expression"\fR
 The inverse of \fBprogram_regex\fR to filter out logs from programs that match.
 
-Multiple \fBprogram_neg_regex\fR may be defined in a section.
+A \fBprogram_neg_regex\fR match will override any \fBprogram_regex\fR matches
+and not log the message.
+
+When one or more \fBprogram_regex\fR are provided, at least one of them must
+match to log the message. The lack of any \fBprogram_regex\fR will result in
+message being logged when no \fBprogram_neg_regex\fR match.
+
+Multiple \fBprogram_neg_regex\fR may be defined in a section, only one must match.
 .TP
 \fBshowrepeats\fR = \fI<number>\fR
 Set to \fI0\fR to filter out repeat log messages.

--- a/src/metalog.c
+++ b/src/metalog.c
@@ -1185,19 +1185,25 @@ static int processLogLine(const int logcode,
                     if (pcre2_match(this_regex->regex,
                                     (PCRE2_SPTR)prg, (PCRE2_SIZE)prg_len,
                                     0, 0, match_data, NULL) >= 0) {
+                        /* pass, unless a program_neg_regex matches */
                         regex_result = 1;
+                    } else if (regex_result != 1) {
+                        /* fail, unless another program_regex matches */
+                        regex_result = -1;
                     }
                 } else {
                     if (pcre2_match(this_regex->regex,
                                     (PCRE2_SPTR)prg, (PCRE2_SIZE)prg_len,
-                                    0, 0, match_data, NULL) < 0) {
-                        regex_result = 1;
+                                    0, 0, match_data, NULL) >= 0) {
+                        /* fail immediately */
+                        goto nextblock;
                     }
+                    /* pass, unless a non-matching program_regex is found or another program_neg_regex matches */
                 }
                 this_regex++;
                 nb_regexes--;
             } while (nb_regexes > 0);
-            if (regex_result == 0) {
+            if (regex_result == -1) {
                 goto nextblock;
             }
         }
@@ -1212,19 +1218,25 @@ static int processLogLine(const int logcode,
                     if (pcre2_match(this_regex->regex,
                                     (PCRE2_SPTR)info, (PCRE2_SIZE)info_len,
                                     0, 0, match_data, NULL) >= 0) {
+                        /* pass, unless a neg_regex matches */
                         regex_result = 1;
+                    } else if (regex_result != 1) {
+                        /* fail, unless another regex matches */
+                        regex_result = -1;
                     }
                 } else {
                     if (pcre2_match(this_regex->regex,
                                     (PCRE2_SPTR)info, (PCRE2_SIZE)info_len,
-                                    0, 0, match_data, NULL) < 0) {
-                        regex_result = 1;
+                                    0, 0, match_data, NULL) >= 0) {
+                        /* fail immediately */
+                        goto nextblock;
                     }
+                    /* pass, unless a non-matching regex is found or another neg_regex matches */
                 }
                 this_regex++;
                 nb_regexes--;
             } while (nb_regexes > 0);
-            if (regex_result == 0) {
+            if (regex_result == -1) {
                 goto nextblock;
             }
         }


### PR DESCRIPTION
Multiple neg_regex required all to match to discard a message. Now only one must match, allowing patterns to be spread out over several neg_regex conditions.

Non-matching neg_regex would cause a message to be logged even if all regex conditions did not match. This now requires at least one regex to match, or no regex conditions to be given.

Fixes #17.