### PR TITLE
configure.ac: Silence obsolete warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@ AC_INIT([metalog], [4], [metalog-users@lists.sourceforge.net])
 AM_INIT_AUTOMAKE([1.11 dist-xz no-dist-gzip silent-rules -Wall])
 AM_SILENT_RULES([yes])
 AC_CONFIG_SRCDIR(src/metalog.c)
-AM_CONFIG_HEADER(config.h)
+AC_CONFIG_HEADERS([config.h])
 
 gl_cv_func_printf_infinite_long_double=yes
 
@@ -11,7 +11,6 @@ dnl Checks for programs.
 AC_PROG_INSTALL
 AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_CC
-AC_PROG_CC_STDC
 AC_SYS_LARGEFILE
 PKG_PROG_PKG_CONFIG
 
@@ -27,7 +26,6 @@ AC_C_CONST
 AC_TYPE_MODE_T
 AC_TYPE_PID_T
 AC_STRUCT_TM
-AC_TYPE_SIGNAL
 AC_TYPE_UID_T
 AC_TYPE_OFF_T
 
@@ -36,21 +34,24 @@ dnl Options
 AM_WITH_DMALLOC
 
 AC_MSG_CHECKING([whether syslog names are available])
-AC_TRY_COMPILE([
-#define SYSLOG_NAMES 1
-#include <stdio.h>
-#include <syslog.h>
-],
-[
- (void) facilitynames
-],
-[
-  AC_MSG_RESULT(yes)
-  AC_DEFINE(HAVE_SYSLOG_NAMES, , [Define if syslog names are defined])
-],
-[
-  AC_MSG_RESULT(no)
-])  
+AC_COMPILE_IFELSE(
+	[AC_LANG_PROGRAM(
+		[[
+			#define SYSLOG_NAMES 1
+			#include <stdio.h>
+			#include <syslog.h>
+		]],
+		[[
+			(void) facilitynames
+		]],
+	)],
+	[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_SYSLOG_NAMES, , [Define if syslog names are defined])
+	],
+	[
+		AC_MSG_RESULT(no)
+	])
 
 dnl Checks for libraries.
 
@@ -93,7 +94,7 @@ W_CHECK_CFLAG([-Wreturn-type])
 AC_SUBST(WFLAGS, $WFLAGS)
 
 AC_ARG_WITH(unicode,
-	[AC_HELP_STRING([--with-unicode],[Enable unicode support (default no)])])
+	[AS_HELP_STRING([--with-unicode],[Enable unicode support (default no)])])
 AS_IF([test "x$with_unicode" = "xyes"], [
 	AC_DEFINE([ACCEPT_UNICODE_CONTROL_CHARS], [1], [Don't scramble unicode])
 ])

--- a/src/metalog.c
+++ b/src/metalog.c
@@ -1540,13 +1540,13 @@ static void metalog_signal_exit(int exit_status)
 }
 
 __attribute__ ((noreturn))
-static RETSIGTYPE sigkchld(int sig)
+static void sigkchld(int sig)
 {
     signal_doLog_queue("Process [%u] died with signal [%d]\n", (unsigned int) getpid(), sig);
     metalog_signal_exit(EXIT_FAILURE);
 }
 
-static RETSIGTYPE sigchld(int sig)
+static void sigchld(int sig)
 {
     pid_t pid;
     signed char should_exit = 0;
@@ -1574,7 +1574,7 @@ static RETSIGTYPE sigchld(int sig)
     }
 }
 
-static RETSIGTYPE sigusr1(int sig)
+static void sigusr1(int sig)
 {
     (void) sig;
 
@@ -1583,7 +1583,7 @@ static RETSIGTYPE sigusr1(int sig)
     flushAll();
 }
 
-static RETSIGTYPE sigusr2(int sig)
+static void sigusr2(int sig)
 {
     (void) sig;
 


### PR DESCRIPTION
This silences the obsolete warnings with autoconf 2.69 and 2.71 when using `autoreconf -fi`. To that end `RETSIGTYPE` was replaced with `void` in `src/metalog.c` as it is already defined in `config.h`.
```
configure.ac:6: warning: 'AM_CONFIG_HEADER': this macro is obsolete.
configure.ac:6: You should use the 'AC_CONFIG_HEADERS' macro instead.
./lib/autoconf/general.m4:2434: AC_DIAGNOSE is expanded from...
aclocal.m4:1166: AM_CONFIG_HEADER is expanded from...
configure.ac:6: the top level
configure.ac:14: warning: The macro `AC_PROG_CC_STDC' is obsolete.
configure.ac:14: You should run autoupdate.
./lib/autoconf/c.m4:1671: AC_PROG_CC_STDC is expanded from...
configure.ac:14: the top level
configure.ac:30: warning: The macro `AC_TYPE_SIGNAL' is obsolete.
configure.ac:30: You should run autoupdate.
./lib/autoconf/types.m4:776: AC_TYPE_SIGNAL is expanded from...
configure.ac:30: the top level
configure.ac:39: warning: The macro `AC_TRY_COMPILE' is obsolete.
configure.ac:39: You should run autoupdate.
./lib/autoconf/general.m4:2847: AC_TRY_COMPILE is expanded from...
configure.ac:39: the top level
configure.ac:95: warning: The macro `AC_HELP_STRING' is obsolete.
configure.ac:95: You should run autoupdate.
./lib/autoconf/general.m4:204: AC_HELP_STRING is expanded from...
```