### PR TITLE
Trailing newline

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 * Version (not released, yet)
  - m-kress:
- -- do not substitute trailing control characters of a log line, but eliminate them completelly
+ -- Do not substitute trailing control characters of a log line, but eliminate them completelly.
+    Be aware, that this change will break existing filters that rely on the trailing underscore!
 
 * Version 20230707
  - m-kress:

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 * Version (not released, yet)
  - m-kress:
+ -- do not substitute trailing control characters of a log line, but eliminate them completelly
+
+* Version 20230707
+ - m-kress:
  -- add missing brackets to harmonize code
  - auouymous:
  -- fix behavior of (program_)?regex and (program_)?neg_regex conditions

--- a/src/metalog.c
+++ b/src/metalog.c
@@ -1381,12 +1381,10 @@ static void sanitize(char * const line_)
             /* eliminate a trailing control character (even '\n'), if it is the last one in this line */
             if (*(line + 1) == 0U) {
                 *line = 0U;
-                printf("vorzeitiges Ende der Zeile\n");
             }
             else {
                 /* substitude a control character if it is in the middle of the line */
                 *line = NONPRINTABLE_SUSTITUTE_CHAR;
-                printf("ersetze mit _\n");
             }
         }
         line++;

--- a/src/metalog.c
+++ b/src/metalog.c
@@ -1210,13 +1210,6 @@ static int get_stamp_fmt_timestamp(const char *stamp_fmt, char *datebuf, int dat
     return 0;
 }
 
-static int log_stdout(const char * const date,
-                      const char * const prg, const char * const info)
-{
-    printf("%s [%s] %s\n", date, prg, info);
-    return 0;
-}
-
 static int processLogLine(const int logcode,
                           const char * const prg, char * const info)
 {
@@ -1337,7 +1330,7 @@ static int processLogLine(const int logcode,
             writeLogLine(block->output, datebuf, prg, info);
 
             /* write to stdout */
-            log_stdout(datebuf, prg, info);
+            printf("%s [%s] %s\n", datebuf, prg, info);
 
             /* send the log entry to the remote host */
             if (remote_host.hostname != NULL && block->remote_log) {

--- a/src/metalog.c
+++ b/src/metalog.c
@@ -1376,8 +1376,18 @@ static void sanitize(char * const line_)
     register unsigned char *line = (unsigned char *) line_;
 
     while (*line != 0U) {
+        /* replace a control characters of the line */
         if (ISCTRLCODE(*line)) {
-            *line = NONPRINTABLE_SUSTITUTE_CHAR;
+            /* eliminate a trailing control character (even '\n'), if it is the last one in this line */
+            if (*(line + 1) == 0U) {
+                *line = 0U;
+                printf("vorzeitiges Ende der Zeile\n");
+            }
+            else {
+                /* substitude a control character if it is in the middle of the line */
+                *line = NONPRINTABLE_SUSTITUTE_CHAR;
+                printf("ersetze mit _\n");
+            }
         }
         line++;
     }

--- a/src/metalog.c
+++ b/src/metalog.c
@@ -1376,7 +1376,7 @@ static void sanitize(char * const line_)
     register unsigned char *line = (unsigned char *) line_;
 
     while (*line != 0U) {
-        /* replace a control characters of the line */
+        /* replace control characters of the line */
         if (ISCTRLCODE(*line)) {
             /* eliminate a trailing control character (even '\n'), if it is the last one in this line */
             if (*(line + 1) == 0U) {

--- a/src/metalog.h
+++ b/src/metalog.h
@@ -183,9 +183,9 @@ typedef enum LogLineType_ {
 #define DEFAULT_UPD_PORT "514"              /* UDP port of the remote syslog server */
 #define DEFAULT_DNS_LOOKUP_INTERVERVAL 120  /* seconds, after that a DNS lookup should be repeated */
 
-/* "DEL" character or all characters < "SPACE" (< 0x20) */
+/* "DEL" (0x7f) character or all characters < "SPACE" (0x20) */
 #ifdef ACCEPT_UNICODE_CONTROL_CHARS
-# define ISCTRLCODE(X) ((X) == 0x7f || ((unsigned char) (X)) < 32U)
+# define ISCTRLCODE(X) ((X) == 0x7f || ((unsigned char) (X)) < 0x20)
 #else
 # define ISCTRLCODE(X) ((X) == 0x7f || !(((unsigned char) (X)) & 0x60))
 #endif

--- a/src/metalog.h
+++ b/src/metalog.h
@@ -183,6 +183,7 @@ typedef enum LogLineType_ {
 #define DEFAULT_UPD_PORT "514"              /* UDP port of the remote syslog server */
 #define DEFAULT_DNS_LOOKUP_INTERVERVAL 120  /* seconds, after that a DNS lookup should be repeated */
 
+/* "DEL" character or all characters < "SPACE" (< 0x20) */
 #ifdef ACCEPT_UNICODE_CONTROL_CHARS
 # define ISCTRLCODE(X) ((X) == 0x7f || ((unsigned char) (X)) < 32U)
 #else

--- a/src/metalog.h
+++ b/src/metalog.h
@@ -183,10 +183,11 @@ typedef enum LogLineType_ {
 #define DEFAULT_UPD_PORT "514"              /* UDP port of the remote syslog server */
 #define DEFAULT_DNS_LOOKUP_INTERVERVAL 120  /* seconds, after that a DNS lookup should be repeated */
 
-/* "DEL" (0x7f) character or all characters < "SPACE" (0x20) */
 #ifdef ACCEPT_UNICODE_CONTROL_CHARS
+/* "DEL" (0x7f) character or all characters < "SPACE" (0x20) */
 # define ISCTRLCODE(X) ((X) == 0x7f || ((unsigned char) (X)) < 0x20)
 #else
+/* "DEL" (0x7f) character or all characters in (extended) ASCII character control groups C0 and C1 */
 # define ISCTRLCODE(X) ((X) == 0x7f || !(((unsigned char) (X)) & 0x60))
 #endif
 


### PR DESCRIPTION
Some programs (e.g. strongswan, fetchmail) or standard libs (musl) append a '\n' to every log line. Metalog substituted every control character (0x7F and 0x0 to 0x1f) with an '_'. This commit does the same exept for control characters trailing a line. This gets rid of the trailing '_' in all logs.

This should not cost too much performance, because control characters in log lines are not very common.

This should deal with issue 20 (https://github.com/hvisage/metalog/issues/20).