### PR TITLE
fix default config file

### DIFF
--- a/man/metalog.conf.5.in
+++ b/man/metalog.conf.5.in
@@ -13,6 +13,8 @@ metalog.conf \- configuration file for metalog
 <section 2 title :>
 <section 2 values>
 
+# Comments are introduced with "#", which is ONLY allowed at the beginning of a line.
+
 <etc.>
 .fi
 .SH "DESCRIPTION"

--- a/metalog.conf
+++ b/metalog.conf
@@ -99,6 +99,34 @@ SSH Server:
     logdir   = "/var/log/sshd"
     break    = 1
 
+# why the hell do you still run that thing !?
+Telnet:
+    program  = "login"
+    logdir   = "/var/log/telnet"
+    break    = 1
+
+Imap:
+     program  = "/usr/sbin/imapd"
+     logdir   = "/var/log/imap"
+     break    = 1
+
+POP Toaster:
+    program  = "/usr/sbin/ipop3d"
+    logdir   = "/var/log/pop"
+    break    = 1
+
+Mail:
+    facility = "mail"
+    neg_regex= "starting daemon"
+    logdir   = "/var/log/mail"
+    break    = 1
+
+# exim stuff - log output from every program whose name begins with "exim".
+Exim:
+    program_regex = "^exim"
+    logdir        = "/var/log/exim"
+    break         = 1
+
 Imap:
     program  = "/usr/sbin/imapd"
     logdir   = "/var/log/imap"

--- a/metalog.conf
+++ b/metalog.conf
@@ -132,12 +132,6 @@ Imap:
     logdir   = "/var/log/imap"
     break    = 1
 
-Mail:
-    facility = "mail"
-    neg_regex= "starting daemon"
-    logdir   = "/var/log/mail"
-    break    = 1
-
 # log output from every program whose name begins with "ppp"
 Ppp:
     program_regex = "^ppp"

--- a/metalog.conf
+++ b/metalog.conf
@@ -1,8 +1,15 @@
 # Sample Metalog configuration file
 
-maxsize  = 1048576  # size in bytes (1048576 = 1 megabyte)
-maxtime  = 86400    # time in seconds (86400 = 1 day)
-maxfiles = 5        # num files per directory
+# Comments are introduced with "#", which is ONLY allowed at the beginning of a line.
+
+# Rotate log after file size (1048576 = 1 megabyte)
+maxsize  = 1048576
+
+# Rotate log at least after 30 days (in seconds)
+maxtime  = 2592000
+
+# Number of archive files per directory
+maxfiles = 5
 
 # Permissions for log directories. 0750 allows group to read logs. 0700 is default.
 #perms    = 0750
@@ -21,11 +28,11 @@ maxfiles = 5        # num files per directory
 # generates.  If you use any "command" options below, you will want this
 # as metalog generates a lot of status messages whenever it executes a
 # command and children processes exit.
-#Metalog :
 #
-#  program   = "metalog"
-#  logdir    = "/var/log/metalog"
-#  break     = 1
+#Metalog:
+#    program   = "metalog"
+#    logdir    = "/var/log/metalog"
+#    break     = 1
 
 # Uncomment and adjust the following lines according to your console logging
 # needs.  If you want to only output things that were not caught by other log
@@ -34,26 +41,22 @@ maxfiles = 5        # num files per directory
 # merely write $@ to some device (your console for messages):
 # echo "$@" > /dev/tty10
 #
-#console logging :
-#
+#console logging:
 #  facility  = "*"
 #  command   = "/sbin/consolelog.sh"
 
-Everything important :
-
+Everything important:
     facility = "*"
     minimum  = 6
     logdir   = "/var/log/everything"
 #if break keyword does not appear, rules after here will be run.
 
-Everything very important :
-
+Everything very important:
     facility = "*"
     minimum  = 1
     logdir   = "/var/log/critical"
 
-Password failures :
-
+Password failures:
     regex    = "(password|login|authentication)\s+(fail|invalid)"
     regex    = "(failed|invalid)\s+(password|login|authentication|user)"
     regex    = "ILLEGAL ROOT LOGIN"
@@ -64,103 +67,67 @@ Password failures :
 # restrictive permissions on sensitive logs.
 #    perms    = 0700
 
-Kernel messages :
-
+Kernel messages:
     facility = "kern"
     logdir   = "/var/log/kernel"
     break    = 1
 # Additionally send this log entries via UDP to a remote log server
 #    remote_log = 1
 
-Crond :
-
+Crond:
     facility = "cron"
     logdir   = "/var/log/cron"
     break    = 1
 
-Dudes firewalled by IPTrap :
-
+Dudes firewalled by IPTrap:
     program  = "iptrap"
     logdir   = "/var/log/iptrap"
     break    = 1
 
-FTP Server :
-
+FTP Server:
     facility = "ftp"
     logdir   = "/var/log/ftpd"
     break    = 1
 
-News Server :
-
+News Server:
     facility = "news"
     logdir   = "/var/log/news"
     break    = 1
 
-SSH Server :
-
+SSH Server:
     program  = "sshd"
     logdir   = "/var/log/sshd"
     break    = 1
 
-#why the hell do you still run that thing !?
-Telnet :
-
-    program  = "login"
-    logdir   = "/var/log/telnet"
-    break    = 1
-
-Imap :
-
+Imap:
     program  = "/usr/sbin/imapd"
     logdir   = "/var/log/imap"
     break    = 1
 
-POP Toaster :
-
-    program  = "/usr/sbin/ipop3d"
-    logdir   = "/var/log/pop"
-    break    = 1
-
-# Add authenticated IP addresses for SMTP relaying :
-
-#    program  = "/usr/sbin/ipop3d"
-#    regex    = "Login.+nmsgs="
-#    command  = "/usr/local/sbin/add_pop_address.sh"
-#    break    = 1
-
-Mail :
-
+Mail:
     facility = "mail"
     neg_regex= "starting daemon"
     logdir   = "/var/log/mail"
     break    = 1
 
-# exim stuff - log output from every program whose name begins with
-# "exim".
-#
-Exim :
-
-    program_regex = "^exim"
-    logdir        = "/var/log/exim"
-    break         = 1
-
-Ppp :
+# log output from every program whose name begins with "ppp"
+Ppp:
     program_regex = "^ppp"
     logdir    = "/var/log/ppp"
     break     = 1
 
-Postgresql :
+Postgresql:
     program_regex = "^postmaster"
     program_regex = "^postgres"
     logdir    = "/var/log/postgres"
     break     = 1
 
-Apache :
+Apache:
     program_regex = "^httpd"
     logdir    = "/var/log/http"
     break     = 1
 
-HAL :
+HAL:
     program_regex = "^hal"
     logdir    = "/var/log/hal"
     break     = 1


### PR DESCRIPTION
The default config file contains invalid comments, which is quite painful.
This fixes a 12,5 year old bug ticket: https://sourceforge.net/p/metalog/bugs/19
Also ticket #14 could have been avoided, if the rules for comments would have been more prominent in the config and man-page.
Additionally the default config file gets reduced a little bit.