### PR TITLE
new feature: compress option for rotated log files

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -73,10 +73,10 @@ AC_CHECK_FUNCS_ONCE(m4_flatten([
 dnl Conditional functionality
 
 AC_ARG_WITH(compress,
-	[AS_HELP_STRING([--with-compress],[Enable built-in compression of rotated logs (default no)])])
-AS_IF([test "x$with_compress" = "xyes"], [
+	[AS_HELP_STRING([--without-compress],[Disable support for compressing rotated logs])])
+AS_IF([test "x$with_compress" != "xno"], [
 	PKG_CHECK_MODULES([ZLIB], [zlib])
-	AC_DEFINE([WITH_COMPRESS], [1], [Provide built-in compression option])
+	AC_DEFINE([WITH_COMPRESS], [1], [Define to include support for compression with zlib])
 ])
 
 dnl Libraries

--- a/man/metalog.conf.5.in
+++ b/man/metalog.conf.5.in
@@ -238,6 +238,15 @@ only allowed once, all repetitions will be ignored.
 \fBsocket = \fI"/path/to/logging/socket"\fR
 Listen and filter on an additional logging socket. If creation of the sockets fails
 metalog will continue without that source of logs.
+.TP
+\fBcompress = \fI<number>\fR
+Default is \fI0\fR.
+If set to \fI1\fR, rotated logs are compressed in gzip format.
+This option will be ignored if metalog was built without compression support.
+.TP
+\fBcompress_delay = \fI<number>\fR
+Default is \fI0\fR.
+The number of most recent rotated log files to leave uncompressed.
 .SH "FILES"
 .LP
 Note that the exact paths depend on the build settings. These are the standard paths.

--- a/metalog.conf
+++ b/metalog.conf
@@ -11,6 +11,12 @@ maxtime  = 2592000
 # Number of archive files per directory
 maxfiles = 5
 
+# Compress rotated logs
+compress = 1
+
+# Leave one rotated log file uncompressed
+compress_delay = 1
+
 # Directory with more config files to load; files names must end with ".conf"
 #configdir = /etc/metalog.d
 

--- a/src/metalog.h
+++ b/src/metalog.h
@@ -213,7 +213,7 @@ typedef struct ConfigBlock_ {
 #define OUTPUT_DIR_LOGFILES_SUFFIX "%Y-%m-%d-%H:%M:%S"
 #define COMPRESS_SUFFIX ".gz"
 #define COMPRESSED_REGEX "\\.(?:Z|gz|bz2|xz)$"
-#define DEFAULT_COMPRESS_DELAY 1
+#define DEFAULT_COMPRESS_DELAY 0
 #define DEFAULT_CONFIG_FILE CONFDIR "/metalog.conf"
 #define DEFAULT_PID_FILE "/var/run/metalog.pid"
 #define NONPRINTABLE_SUSTITUTE_CHAR '_'


### PR DESCRIPTION
I clicked prematurely to create this - was planning to post as draft initially - so here goes, I'm editing the description!

This PR adds a `compress = 1` option to compress rotated log files that are not pruned. This is a key missing feature from logrotate configurations now integrated into metalog if this change (or a variation of it) is acceptable!

Here is what the output looks like:

```
-rw-r--r-- 1 root adm      28 Dec 24 09:29 current
-rw-r--r-- 1 root adm   44868 Dec 24 08:39 log-2025-12-17-07:11:30.gz
-rw-r--r-- 1 root adm   80103 Dec 24 08:39 log-2025-12-18-00:04:48.gz
-rw-r--r-- 1 root adm  119688 Dec 24 09:29 log-2025-12-21-07:54:17.gz
-rw-r--r-- 1 root adm 1147356 Dec 24 09:29 log-2025-12-24-09:29:22
```

Apart from convenience, this is an improvement on using a postrotate command script to compress the logs because the spawned commands are not reliable - if they haven't finished then future ones will be skipped.

A downside of this solution is that it blocks the main thread to perform the compression. On a modern machine this will be trivial but I did a worst case check on an Intel N270 Atom i386 netbook and it took 150ms to compress a 1.4MB log file.

An approach to fix this would be to have another thread (well, process, since you wouldn't really want to mix threads and forking) that did the compression. That would be more tricky synchronization complexity for not much gain but it could be done if desired.

If you want more uncompressed logs, change `EXTRA_COMPRESSION_DELAY` to `1` or more.

This solution could do with some input from an _autotools_ expert to make the zlib dependency optional. `zlib` is pretty universal - it's even in the LSB - so maybe this isn't needed. It's also possible that I picked some `*at()` functions that are in too new an edition of POSIX for moderately recent BSDs - I could possibly use some help there too.