### PR TITLE
ignore config filenames with characters after .conf

### DIFF
--- a/src/metalog.h
+++ b/src/metalog.h
@@ -213,6 +213,7 @@ typedef struct ConfigBlock_ {
 #define OUTPUT_DIR_LOGFILES_SUFFIX "%Y-%m-%d-%H:%M:%S"
 #define COMPRESS_SUFFIX ".gz"
 #define COMPRESSED_REGEX "\\.(?:Z|gz|bz2|xz)$"
+#define CONFFILE_REGEX "\\.conf$"
 #define DEFAULT_COMPRESS_DELAY 0
 #define DEFAULT_CONFIG_FILE CONFDIR "/metalog.conf"
 #define DEFAULT_PID_FILE "/var/run/metalog.pid"


### PR DESCRIPTION
I think this problem existed before the recent changes but if you have files like the following:

```
-rw-r--r-- 1 root root 100 Dec 19 12:39 10_permissions.conf
-rw-r--r-- 1 root root 423 Jan  5 08:44 10_rotation.conf
-rw-r--r-- 1 root root 275 Jan  1 22:43 10_rotation.conf.dpkg-old
-rw-r--r-- 1 root root 461 Dec 19 12:39 50_facilities.conf
-rw-r--r-- 1 root root 144 Dec 19 12:39 90_syslog.conf
```

then `10_rotation.conf.dpkg-old`, which has been created by a package manager on upgrade, overrides `10_rotation.conf`, which is clearly not anyone's intention.

This fix uses a regex, since we already use PCRE2. Presently this is hard-coded in the header file, which is easy for downstream distros to patch to something different if they want and also if we wanted in future we could make it configurable more easily now.