### PR TITLE
add -S, --socket option to change main syslog socket

### DIFF
--- a/README
+++ b/README
@@ -463,6 +463,9 @@ Created files will be owned by this group.
 - '-p <filename>' or '--pidfile=<filename>': set the name of the file
 that will hold the PID number. It defaults to /var/run/metalog.pid
 
+- '-S <pathname>' or '--socket=<pathname>': set the path that will
+name the main syslog socket. It defaults to /dev/log
+
 - '-s' or '--sync': start in synchronous mode, with no bufferization.
 
 - '-t' or '--test-config': Exit after parsing the config file(s).

--- a/man/metalog.8.in
+++ b/man/metalog.8.in
@@ -52,6 +52,9 @@ Do not attempt to log messages from the kernel.
 .BR \-p ", " \-\-pidfile = \fR\fIfile\fR
 Use an alternate file to store the process number.
 .TP
+.BR \-S ", " \-\-socket = \fR\fIpath\fR
+Use an alternate socket path for main syslog listener.
+.TP
 .BR \-s ", " \-\-sync ", " \-\-synchronous
 Start in synchronous mode, with no bufferization.
 Can be overridden for individual logs.

--- a/src/metalog.c
+++ b/src/metalog.c
@@ -2582,6 +2582,9 @@ static void parseOptions(int argc, char *argv[])
         case 'p' :
             pid_file = xstrdup(optarg);
             break;
+        case 'S' :
+            sock_name = xstrdup(optarg);
+            break;
         case 's' :
             break;
         case 't' :
@@ -2643,7 +2646,7 @@ int main(int argc, char *argv[])
     if (do_kernel_log) {
         add_data_source(LOGLINETYPE_KLOG, NULL, false);
     }
-    add_data_source(LOGLINETYPE_SYSLOG, SOCKNAME, true);
+    add_data_source(LOGLINETYPE_SYSLOG, sock_name, true);
     ret = configParser(config_file);
     if (test_config) {
         return ret;

--- a/src/metalog.h
+++ b/src/metalog.h
@@ -51,9 +51,9 @@
 #include "helpers.h"
 
 #ifdef _PATH_LOG
-# define SOCKNAME _PATH_LOG
+# define DEFAULT_SOCK_NAME _PATH_LOG
 #else
-# define SOCKNAME "/dev/log"
+# define DEFAULT_SOCK_NAME "/dev/log"
 #endif
 #ifdef _PATH_KLOG
 # define KLOG_FILE _PATH_KLOG

--- a/src/metalog_p.h
+++ b/src/metalog_p.h
@@ -6,7 +6,7 @@
 #else
 # define KLOGCTL_OPTIONS ""
 #endif
-#define GETOPT_OPTIONS KLOGCTL_OPTIONS "aBC:g:hp:stVvN"
+#define GETOPT_OPTIONS KLOGCTL_OPTIONS "aBC:g:hp:S:stVvN"
 
 static struct option long_options[] = {
     { "async",        0, NULL, 'a' },
@@ -19,6 +19,7 @@ static struct option long_options[] = {
     { "help",         0, NULL, 'h' },
     { "no-kernel",    0, NULL, 'N' },
     { "pidfile",      1, NULL, 'p' },
+    { "socket",       1, NULL, 'S' },
     { "synchronous",  0, NULL, 's' },
     { "sync",         0, NULL, 's' },
     { "test-config",  0, NULL, 't' },
@@ -43,6 +44,7 @@ static int verbose;
 static int test_config;
 static bool do_kernel_log = true;
 static signed char daemonize;
+static const char *sock_name = DEFAULT_SOCK_NAME;
 static const char *pid_file = DEFAULT_PID_FILE;
 static const char *config_file = DEFAULT_CONFIG_FILE;
 static const char *config_dir = NULL;


### PR DESCRIPTION
This patch adds a command line option to change the main syslog unix listening path from the default of `/dev/log`.

There are multiple use cases for this feature. I think it is typical for a unix service to allow such a path to be overridden at runtime and this contributes to the general 'composability' of system tools.

The implementation extends the pattern already used for other defaults, such as the pid file (hence how I discovered #45).

### Use cases

- Testing. This feature will help with the construction of system test cases [^1] by allowing an unprivileged user to launch metalog with an arbitrary listening path and connect to it, e.g. with `logger -u`.
- Allowing system administrators to set up unusual syslog routing within a system (such as involving containers), perhaps proxying syslog connections.
- Enabling use as a secondary logger downstream of another logger, such as systemd-journald, that adds in its own messages. (Closes #44)

There is a discussion on #44 about the merits or otherwise of making any change to facilitate systemd users but if one considers it undesirable, then one can think of that aspect of this pull request as being *incidental* and judge it on its merits for the other use cases and as a generalisation in line with typical system tooling.

[^1]: I intend to contribute such a case to the forthcoming Debian package in due course using the *autopkgtest* mechanism and this would be a useful enabling feature for that.